### PR TITLE
Chore/prepare release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 23-04-2024
+
+Se cambian funcionalidades. Funciona con la versión 4.0.0 del [Agente Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent/releases)
+
+### Fixed
+
+- Para conectar al agente, ahora se utiliza correctamente la URL pasada como parámetro al método `connect("socketUrl")`.
+
+### Changed
+
+- La URL a la que se conecta por defecto el método `connect("socketUrl")` ahora es _https://localhost:8090_
+
 ## [3.1.1] - 15-09-2021
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Se cambian funcionalidades. Funciona con la versión 4.0.0 del [Agente Web](http
 
 ### Fixed
 
-- Para conectar al agente, ahora se utiliza correctamente la URL pasada como parámetro al método `connect("socketUrl")`.
+- Se corrige el método para conectar con el agente, ahora se utiliza correctamente la URL pasada como parámetro al método `connect("socketUrl")`. Anteriormente solo conectaba a la URL por defecto.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.ht
 
 ## [4.0.0] - 23-04-2024
 
-Se cambian funcionalidades. Funciona con la versión 4.0.0 del [Agente Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent/releases)
+Funciona con la versión 4.0.0 del [Agente Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent/releases)
 
 ### Fixed
 

--- a/index.html
+++ b/index.html
@@ -6,23 +6,20 @@
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Demo</title>
-</head>
-<body>
-  Hola
-
   <script src="./dist/pos.js"></script>
   <script>
       Transbank.POS.connect().then(function() {
           console.log('Conectado al cliente')
-          // Pueders usar Transbank.POS.getPorts() para obtener lista de puertos activos
-          Transbank.POS.openPort('/dev/cu.usbmodem0123456789ABCD1').then(function(ports) {
-              console.log('Puerto conectado')
-              Transbank.POS.doSale(1500, 'ticket1234124').then(function(result) {
-                  console.log('resultado venta', result)
-              });
+          Transbank.POS.getPorts().then(function(ports){
+            console.log(ports)
           });
       })
     console.log();
   </script>
+</head>
+<body>
+  Hola
+
+
 </body>
 </html>

--- a/src/pos.js
+++ b/src/pos.js
@@ -23,8 +23,8 @@ export class TransbankPOSWebSocket extends EventEmitter {
         return this.socket;
     }
 
-    async connect(socketIoUrl = "http://localhost:8090") {
-        this.socket = io("http://localhost:8090")
+    async connect(socketIoUrl = "https://localhost:8090") {
+        this.socket = io(socketIoUrl)
         this.isConnected = true
 
         this.socket.on("connect", () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = [
         umdNamedDefine: true
     },
     node: {
-        net: 'empty',
+        net: 'empty'
     },
     module: {
         rules: [


### PR DESCRIPTION
PR for release 4.0.0

This release includes the following changes:

- Now the URL passed as a parameter is being used correctly in `connect("socketUrl")` method.
- Default URL for method`connect("socketUrl")` now is _https://localhost:8090_